### PR TITLE
Fix mobile search page layout - remove unnecessary scrolling

### DIFF
--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -125,7 +125,7 @@ export default function Home() {
   </button>
 
     {!submitted ? (
-      <div className="search-screen" style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      <div className="search-screen" style={{ flex: 'none', display: 'flex', flexDirection: 'column', justifyContent: 'flex-start' }}>
         <h1 className="search-title">GitHub Portfolio Viewer</h1>
         <form
           onSubmit={(e) => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,8 +19,10 @@ body.dark-mode {
 }
 
 main {
-  min-height: 100vh;
+  min-height: calc(100vh - 60px); /* מקום ל-footer */
   background-color: inherit;
+  display: flex;
+  flex-direction: column;
 }
 
 /* קונטיינר ראשי */
@@ -563,10 +565,18 @@ body.dark-mode .resume-menu a:hover {
 
   /* Search screen mobile layout */
   .search-screen {
-    min-height: calc(100vh - 60px);
-    justify-content: flex-start;
+    min-height: auto !important;
+    justify-content: flex-start !important;
     padding: 1rem;
-    padding-top: 2rem;
+    padding-top: 1rem;
+  }
+
+  /* במצב חיפוש, מניעת מיקום מרכזי במובייל */
+  .search-mode .search-screen {
+    justify-content: flex-start !important;
+    min-height: auto !important;
+    padding: 1rem;
+    padding-top: 1rem;
   }
 
   /* Title adjustments */
@@ -767,7 +777,15 @@ body.dark-mode .resume-menu a:hover {
 @media (max-width: 480px) {
   .search-screen {
     padding: 0.8rem;
-    padding-top: 2rem;
+    padding-top: 1rem !important;
+    min-height: auto !important;
+    justify-content: flex-start !important;
+  }
+
+  .search-mode .search-screen {
+    padding: 0.8rem;
+    padding-top: 1rem !important;
+    justify-content: flex-start !important;
   }
 
   .search-title {
@@ -850,10 +868,10 @@ html {
 }
 
 .search-mode .search-screen {
-  flex: 1;
+  flex: none;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   min-height: auto;
   padding: 1rem 2rem;
 }


### PR DESCRIPTION
- Fixed excessive white space on mobile search screen
- Changed justify-content from center to flex-start for search-screen
- Removed unnecessary min-height causing extra scrolling
- Updated inline styles in search component to prevent centering
- Improved footer positioning without forcing scroll
- Enhanced mobile UX by eliminating dead space

Mobile users can now see content immediately without scrolling to find the footer