### PR TITLE
Fix mobile profile icons - clean icon-only display

### DIFF
--- a/components/ResumeDropdown.tsx
+++ b/components/ResumeDropdown.tsx
@@ -4,7 +4,19 @@ import { FaFileAlt } from 'react-icons/fa';
 
 export default function ResumeDropdown() {
   const [open, setOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+
+  // זיהוי מובייל
+  useEffect(() => {
+    const checkIsMobile = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+    
+    checkIsMobile();
+    window.addEventListener('resize', checkIsMobile);
+    return () => window.removeEventListener('resize', checkIsMobile);
+  }, []);
 
   // סגירה אוטומטית אם לוחצים מחוץ לרכיב
   useEffect(() => {
@@ -17,12 +29,28 @@ export default function ResumeDropdown() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  // במובייל - הורדה ישירה, בדסקטופ - תפריט
+  const handleClick = () => {
+    if (isMobile) {
+      // הורדה ישירה במובייל
+      const link = document.createElement('a');
+      link.href = '/Hod_Mitrany_Resume.pdf';
+      link.download = 'Hod_Mitrany_Resume.pdf';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      // תפריט בדסקטופ
+      setOpen(!open);
+    }
+  };
+
   return (
     <div className="resume-dropdown" ref={ref}>
-      <a onClick={() => setOpen(!open)} className="profile-link">
+      <a onClick={handleClick} className="profile-link">
         <FaFileAlt /> <span className="link-text">Resume</span>
       </a>
-      {open && (
+      {!isMobile && open && (
         <div className="resume-menu">
           <a href="/Hod_Mitrany_Resume.pdf" download>Download PDF</a>
           <a href="/Hod_Mitrany_Resume.pdf" target="_blank">View PDF</a>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -698,6 +698,11 @@ body.dark-mode .resume-menu a:hover {
   .link-text {
     display: none !important;
   }
+
+  /* Hide resume dropdown menu on mobile */
+  .resume-menu {
+    display: none !important;
+  }
   
   /* Make all profile links circular and icon-only */
   .profile-links a,
@@ -710,11 +715,23 @@ body.dark-mode .resume-menu a:hover {
     justify-content: center !important;
     align-items: center !important;
     padding: 0 !important;
-    font-size: 1.3rem !important;
+    font-size: 1.2rem !important;
     text-align: center !important;
     display: inline-flex !important;
     max-width: 50px !important;
     position: relative !important;
+    overflow: hidden !important;
+  }
+
+  /* Completely hide any text content */
+  .profile-links a span,
+  .profile-links .profile-link span,
+  .profile-links .resume-dropdown span {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    width: 0 !important;
+    height: 0 !important;
   }
 
   /* Show only icons and hide text */
@@ -723,18 +740,19 @@ body.dark-mode .resume-menu a:hover {
     display: none !important;
   }
 
-  /* Ensure icons are visible */
+  /* Ensure icons are visible and properly sized */
   .profile-links a svg,
   .profile-links .profile-link svg,
   .profile-links .resume-dropdown .profile-link svg {
     display: inline-block !important;
-    font-size: 1.3rem !important;
+    font-size: 1.2rem !important;
     z-index: 1 !important;
     color: inherit !important;
-    width: 1.3rem !important;
-    height: 1.3rem !important;
+    width: 1.2rem !important;
+    height: 1.2rem !important;
     opacity: 1 !important;
     visibility: visible !important;
+    margin: 0 !important;
   }
 
   /* Specific targeting for React Icons */


### PR DESCRIPTION
- Hide all text content in mobile profile links (LinkedIn, GitHub, Resume)
- Hide resume dropdown menu completely on mobile
- Make resume button download PDF directly on mobile (no menu)
- Ensure only icons are visible in circular buttons
- Improved icon sizing and positioning for better mobile UX
- Added mobile detection to ResumeDropdown component

Mobile now shows clean circular icons without any text or dropdown menus